### PR TITLE
Performance: Don't recompile blacklist regexes on every profanity check

### DIFF
--- a/lib/obscenity/base.rb
+++ b/lib/obscenity/base.rb
@@ -8,6 +8,13 @@ module Obscenity
 
       def blacklist=(value)
         @blacklist = value == :default ? set_list_content(Obscenity::Config.new.blacklist) : value
+        @blacklist_regexes = nil
+      end
+
+      def blacklist_regexes
+        @blacklist_regexes ||= blacklist.each_with_object([]) do |foul, result|
+          result << term_regex(foul) unless whitelist.include?(foul)
+        end
       end
 
       def whitelist
@@ -20,8 +27,8 @@ module Obscenity
 
       def profane?(text)
         return(false) unless text.to_s.size >= 3
-        blacklist.each do |foul|
-          return(true) if text =~ term_regex(foul) && !whitelist.include?(foul)
+        blacklist_regexes.each do |foul|
+          return(true) if text =~ foul
         end
         false
       end


### PR DESCRIPTION
This is a performance improvement to the gem. It's inefficient to recompile the blacklist regexes every time a term is checked.  Instead, we cache the compiled regexes in a member variable.  That variable is cleared if the blacklist is reset (though of course, if the blacklist is mutated directly, we won't know about it).